### PR TITLE
Fix SmoothStream contents with tfhd boxes with stsd flag.

### DIFF
--- a/libavformat/mov.c
+++ b/libavformat/mov.c
@@ -2508,7 +2508,7 @@ static int mov_read_tfhd(MOVContext *c, AVIOContext *pb, MOVAtom atom)
         frag->base_data_offset = flags & MOV_TFHD_BASE_DATA_OFFSET ?
             avio_rb64(pb) : frag->moof_offset;
         frag->track_id = 1; /* only one for smooth */
-        frag->stsd_id = 1;
+        frag->stsd_id = flags & MOV_TFHD_STSD_ID ? avio_rb32(pb) : 1;
         frag->duration = flags & MOV_TFHD_DEFAULT_DURATION ?
             avio_rb32(pb) : 0;
         frag->size = flags & MOV_TFHD_DEFAULT_SIZE ?


### PR DESCRIPTION
This patches fixes playback for SmoothStreaming contents that contains STSD flag in TFHD boxes.

We did found some contents with this flag set in subtitles track (TTML).

If STSD flag is set, the current code does not read it (avio_rb32), then the following values to be read in this box (duration and size) received shifted values. In our failed test, duration received the stsd value and size received the duration value. As duration scale is 1/10000000 of second, a 2 second fragment became a 20MB fragment and read function was attempting to read 20MB of subtitles before returing any packet to demux.